### PR TITLE
[fix]refs #7 コピーライトの文章を修正

### DIFF
--- a/product.html
+++ b/product.html
@@ -199,7 +199,8 @@
                 </nav>
                 <p id="copyright">
                     <small>
-                        &copy; 2020-<script>document.write(new Date().getFullYear());</script>, Sugar Company.
+                        <!-- &copy; 2020-<script>document.write(new Date().getFullYear());</script> Sugar Bomber Corp. -->
+                        &copy; 2021 Sugar Bomber Corp.
                     </small>
                 </p>
             </div> <!-- /.contentsMaxWidth /.contentsSidePadding -->


### PR DESCRIPTION
'2020-2021, Sugar Company.' -> '2021 Sugar Bomber Corp.'
This merge resolves #7.