### PR TITLE
[update]refs #54 bicolorSectionのmargin-topをページヘッダの高さ+1emに変更

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -536,7 +536,7 @@ dt {
 
 /* bicolor section */
 #pageMain .bicolorSection {
-    padding: 4em 0 6em;
+    padding: calc(var(--height-pageHeader) + 1em) 0 6em;
 }
 #pageMain .bicolorSection:nth-child(2n) {
     background: var(--background-color-secondary);


### PR DESCRIPTION
各bicolorSectionにジャンプした時に、そのセクションの上部がページヘッダで隠れてしまわないように値を調整
This merge resolves #54.